### PR TITLE
chore(deps): spipu/html2pdf 5.2.4 → 5.3.3 en /public (CVE-2023-39062)

### DIFF
--- a/public/composer.json
+++ b/public/composer.json
@@ -3,5 +3,10 @@
         "afipsdk/afip.php": "^0.5.3",
         "spipu/html2pdf": "^5.2",
         "phpmailer/phpmailer": "^6.0"
+    },
+    "config": {
+        "platform": {
+            "php": "7.4"
+        }
     }
 }

--- a/public/composer.lock
+++ b/public/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7eb52214aae5792ff0b363ff43c7d96a",
+    "content-hash": "5adbcdefd8ddb49c2a86ee3f69b5c909",
     "packages": [
         {
             "name": "afipsdk/afip.php",
@@ -127,27 +127,26 @@
         },
         {
             "name": "spipu/html2pdf",
-            "version": "v5.2.4",
+            "version": "v5.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spipu/html2pdf.git",
-                "reference": "dcb5671cac3d60ff486cf16df389e3bd0dc16ba4"
+                "reference": "98416dd8eadd3b966f41430b841d3e4dd6eadc6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spipu/html2pdf/zipball/dcb5671cac3d60ff486cf16df389e3bd0dc16ba4",
-                "reference": "dcb5671cac3d60ff486cf16df389e3bd0dc16ba4",
+                "url": "https://api.github.com/repos/spipu/html2pdf/zipball/98416dd8eadd3b966f41430b841d3e4dd6eadc6f",
+                "reference": "98416dd8eadd3b966f41430b841d3e4dd6eadc6f",
                 "shasum": ""
             },
             "require": {
                 "ext-gd": "*",
                 "ext-mbstring": "*",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "tecnickcom/tcpdf": "^6.3"
+                "php": "^7.2 || ^8.0",
+                "tecnickcom/tcpdf": "^6.8"
             },
             "require-dev": {
-                "phake/phake": "^2.0",
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^5.0 || ^9.0"
             },
             "suggest": {
                 "ext-gd": "Allows to embed images into the PDF",
@@ -170,14 +169,18 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Html2Pdf is a HTML to PDF converter written in PHP5 (it uses TCPDF). OFFICIAL PACKAGE",
+            "description": "Html2Pdf is a HTML to PDF converter written in PHP - It uses TCPDF - OFFICIAL PACKAGE",
             "homepage": "http://html2pdf.fr/",
             "keywords": [
                 "html",
                 "html2pdf",
                 "pdf"
             ],
-            "time": "2021-12-16T15:23:31+00:00"
+            "support": {
+                "issues": "https://github.com/spipu/html2pdf/issues",
+                "source": "https://github.com/spipu/html2pdf/tree/v5.3.3"
+            },
+            "time": "2025-06-08T21:47:59+00:00"
         },
         {
             "name": "tecnickcom/tcpdf",
@@ -265,5 +268,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Qué corrige

- `spipu/html2pdf` 5.2.4 → 5.3.3 en `public/`: CVE-2023-39062 / GHSA-99fg-2h75-m92h (XSS, media). El PR #15 de dependabot solo lo llevaba a 5.2.4 y la vulnerabilidad seguía abierta.
- `composer audit` en `public/` queda en **0 advisories**.
- Agrega `config.platform.php = 7.4` igual que en el composer.json raíz, para resolver siempre contra el PHP de producción.

Sin cambios de código: solo `composer.json` (config platform) y `composer.lock`.